### PR TITLE
Carrier configuration for RQ3A.210805.001.A1

### DIFF
--- a/apns-full-conf.xml
+++ b/apns-full-conf.xml
@@ -5215,6 +5215,7 @@
   />
 
   <apn carrier="EE Internet"
+      carrier_id="718"
       mcc="234"
       mnc="31"
       apn="everywhere"
@@ -5227,6 +5228,7 @@
   />
 
   <apn carrier="EE MMS"
+      carrier_id="718"
       mcc="234"
       mnc="31"
       apn="eezone"
@@ -5240,6 +5242,7 @@
   />
 
   <apn carrier="EE Internet"
+      carrier_id="718"
       mcc="234"
       mnc="32"
       apn="everywhere"
@@ -5252,6 +5255,7 @@
   />
 
   <apn carrier="EE MMS"
+      carrier_id="718"
       mcc="234"
       mnc="32"
       apn="eezone"

--- a/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
+++ b/overlay/packages/apps/CarrierConfig/res/xml/vendor.xml
@@ -87,7 +87,7 @@
         <int name="smsToMmsTextThreshold" value="-1" />
         <boolean name="support_swap_after_merge_bool" value="false" />
     </carrier_config>
-    <carrier_config mcc="204" mnc="04" spn="C Spire&#10;">
+    <carrier_config mcc="204" mnc="04" spn="C Spire&#13;">
         <string name="carrier_config_version_string">cspire_nl-0.31</string>
         <int name="cdma_3waycall_flash_delay_int" value="300" />
         <boolean name="config_telephony_use_own_number_for_voicemail_bool" value="true" />
@@ -347,7 +347,7 @@
         <string name="carrier_config_version_string">unleashed_be-0.31</string>
     </carrier_config>
     <carrier_config mcc="208" mnc="00">
-        <string name="carrier_config_version_string">orange_fr-25000000314.31</string>
+        <string name="carrier_config_version_string">orange_fr-25000000322.31</string>
         <boolean name="allow_ussd_requests_via_telephony_manager_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
@@ -370,6 +370,7 @@
         <int name="maxImageWidth" value="2592" />
         <int name="maxMessageSize" value="614400" />
         <boolean name="show_4g_for_lte_data_icon_bool" value="true" />
+        <boolean name="show_wfc_location_privacy_policy_bool" value="true" />
         <int name="volte_replacement_rat_int" value="3" />
         <int name="wfc_spn_format_idx_int" value="1" />
     </carrier_config>
@@ -418,7 +419,7 @@
         <boolean name="show_blocking_pay_phone_option_bool" value="true" />
     </carrier_config>
     <carrier_config mcc="208" mnc="01">
-        <string name="carrier_config_version_string">orange_fr-25000000314.31</string>
+        <string name="carrier_config_version_string">orange_fr-25000000322.31</string>
         <boolean name="allow_ussd_requests_via_telephony_manager_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
@@ -441,11 +442,12 @@
         <int name="maxImageWidth" value="2592" />
         <int name="maxMessageSize" value="614400" />
         <boolean name="show_4g_for_lte_data_icon_bool" value="true" />
+        <boolean name="show_wfc_location_privacy_policy_bool" value="true" />
         <int name="volte_replacement_rat_int" value="3" />
         <int name="wfc_spn_format_idx_int" value="1" />
     </carrier_config>
     <carrier_config mcc="208" mnc="02">
-        <string name="carrier_config_version_string">orange_fr-25000000314.31</string>
+        <string name="carrier_config_version_string">orange_fr-25000000322.31</string>
         <boolean name="allow_ussd_requests_via_telephony_manager_bool" value="false" />
         <string-array name="carrier_metered_apn_types_strings" num="3">
             <item value="default" />
@@ -468,6 +470,7 @@
         <int name="maxImageWidth" value="2592" />
         <int name="maxMessageSize" value="614400" />
         <boolean name="show_4g_for_lte_data_icon_bool" value="true" />
+        <boolean name="show_wfc_location_privacy_policy_bool" value="true" />
         <int name="volte_replacement_rat_int" value="3" />
         <int name="wfc_spn_format_idx_int" value="1" />
     </carrier_config>
@@ -12829,7 +12832,7 @@
         <string name="carrier_config_version_string">311210-0.31</string>
     </carrier_config>
     <carrier_config mcc="311" mnc="230">
-        <string name="carrier_config_version_string">cspire_us-25000000422.31</string>
+        <string name="carrier_config_version_string">cspire_us-25000000423.31</string>
         <int name="carrier_default_wfc_ims_mode_int" value="1" />
         <boolean name="carrier_default_wfc_ims_roaming_enabled_bool" value="true" />
         <int name="carrier_ussd_method_int" value="2" />
@@ -12866,6 +12869,7 @@
         <int name="smsToMmsTextThreshold" value="-1" />
         <boolean name="support_swap_after_merge_bool" value="false" />
         <boolean name="use_wfc_home_network_mode_in_roaming_network_bool" value="true" />
+        <int name="volte_replacement_rat_int" value="6" />
         <int name="wfc_spn_format_idx_int" value="1" />
     </carrier_config>
     <carrier_config mcc="311" mnc="310" spn="LEACO">


### PR DESCRIPTION
```
ignoring carrier  'verizon_us'        
ignoring carrier  'uscc_us'           
ignoring carrier  'verizon_us'        
ignoring carrier  'sprint_us'         
ignoring carrier  'boost_us'          
ignoring carrier  'virgin_us'         
ignoring carrier  'sprintprepaid_us'  
ignoring carrier  'sprint_us'         
ignoring carrier  'sprintwholesale_us'
ignoring carrier  'cellcom_us'        
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'bluegrass_us'      
ignoring carrier  'bluegrass_us'      
ignoring carrier  'cellcom_us'        
ignoring carrier  'tracfoneverizon_us'
ignoring carrier  'xfinity_us'        
ignoring carrier  'spectrum_us'       
ignoring carrier  'verizon_us'        
ignoring carrier  'virgin_us'         
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'uscc_us'           
ignoring carrier  'cellcom_us'        
ignoring carrier  'boost_us'          
ignoring carrier  'sprint_us'         
ignoring carrier  'boost_us'          
ignoring carrier  'virgin_us'         
ignoring carrier  'sprintprepaid_us'  
ignoring carrier  'sprint_us'         
ignoring carrier  'sprintwholesale_us'
```