### PR TITLE
remove ro.vendor.build.svn sysprop

### DIFF
--- a/device-common.mk
+++ b/device-common.mk
@@ -1044,3 +1044,5 @@ include device/google/gs-common/thermal/thermal_hal/device.mk
 # Pixel Logger
 include hardware/google/pixel/PixelLogger/PixelLogger.mk
 #################################################################################
+
+PRODUCT_PROPERTY_OVERRIDES := $(filter-out ro.vendor.build.svn=% , $(PRODUCT_PROPERTY_OVERRIDES))


### PR DESCRIPTION
Value of ro.vendor.build.svn in stock OS image used by adevtool might not match the value specified here, e.g. when base AOSP tag doesn't match the tag that was used for stock OS build.

adevtool automatically adds missing properties, i.e. removal of ro.vendor.build.svn from here means that ro.vendor.build.svn sysprop value from stock OS image will be used instead.